### PR TITLE
docs: unify command descriptions and improve parameter documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # aws-s3-siggy
-Generate presigned URLs for AWS S3 operations (upload, download, delete).
+Generate presigned URLs for AWS S3 operations (upload, download, delete, multipart upload).
 
 
 ```
@@ -49,6 +49,8 @@ siggy upload_part -b <bucket_name> -k <object_key> -u <upload_id> -p <part_numbe
 
 - `-b <bucket_name>`: Required. Name of the S3 bucket.
 - `-k <object_key>`: Required. S3 object key.
+- `-u <upload_id>`: Required for upload_part. The ID of the multipart upload.
+- `-p <part_number>`: Required for upload_part. The part number of the multipart upload.
 
 ## Example
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -18,7 +18,7 @@ func NewDeleteCmd(opts *CmdOptions) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "delete",
-		Short: "Delete object from s3.",
+		Short: "Create delete URL (DeleteObject).",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			presigner := p.NewPresigner(opts.PresignClient)
 			err := presigner.DeleteObject(context.TODO(), deleteOpts.bucketName, deleteOpts.objectKey, time.Duration(2*time.Hour))
@@ -30,10 +30,10 @@ func NewDeleteCmd(opts *CmdOptions) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&deleteOpts.bucketName, "bucketName", "b", "", "Bucket name")
+	cmd.Flags().StringVarP(&deleteOpts.bucketName, "bucketName", "b", "", "Bucket name (required)")
 	cmd.MarkFlagRequired("bucketName")
 
-	cmd.Flags().StringVarP(&deleteOpts.objectKey, "objectKey", "k", "", "Object key")
+	cmd.Flags().StringVarP(&deleteOpts.objectKey, "objectKey", "k", "", "Object key (required)")
 	cmd.MarkFlagRequired("objectKey")
 
 	return cmd

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -18,7 +18,7 @@ func NewGetCmd(opts *CmdOptions) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "get",
-		Short: "Get object from s3.",
+		Short: "Create download URL (GetObject).",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			presigner := p.NewPresigner(opts.PresignClient)
 			err := presigner.GetObject(context.TODO(), getOpts.bucketName, getOpts.objectKey, time.Duration(2*time.Hour))
@@ -30,10 +30,10 @@ func NewGetCmd(opts *CmdOptions) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&getOpts.bucketName, "bucketName", "b", "", "Bucket name")
+	cmd.Flags().StringVarP(&getOpts.bucketName, "bucketName", "b", "", "Bucket name (required)")
 	cmd.MarkFlagRequired("bucketName")
 
-	cmd.Flags().StringVarP(&getOpts.objectKey, "objectKey", "k", "", "Object key")
+	cmd.Flags().StringVarP(&getOpts.objectKey, "objectKey", "k", "", "Object key (required)")
 	cmd.MarkFlagRequired("objectKey")
 
 	return cmd

--- a/cmd/put.go
+++ b/cmd/put.go
@@ -18,7 +18,7 @@ func NewPutCmd(opts *CmdOptions) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "put",
-		Short: "Put object to s3.",
+		Short: "Create upload URL (PutObject).",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			presigner := p.NewPresigner(opts.PresignClient)
 			err := presigner.PutObject(context.TODO(), putOpts.bucketName, putOpts.objectKey, time.Duration(2*time.Hour))
@@ -30,10 +30,10 @@ func NewPutCmd(opts *CmdOptions) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&putOpts.bucketName, "bucketName", "b", "", "Bucket name")
+	cmd.Flags().StringVarP(&putOpts.bucketName, "bucketName", "b", "", "Bucket name (required)")
 	cmd.MarkFlagRequired("bucketName")
 
-	cmd.Flags().StringVarP(&putOpts.objectKey, "objectKey", "k", "", "Object key")
+	cmd.Flags().StringVarP(&putOpts.objectKey, "objectKey", "k", "", "Object key (required)")
 	cmd.MarkFlagRequired("objectKey")
 
 	return cmd

--- a/cmd/upload_part.go
+++ b/cmd/upload_part.go
@@ -21,7 +21,7 @@ func NewUploadPartCmd(opts *CmdOptions) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "upload_part",
-		Short: "Upload part to s3 multipart upload.",
+		Short: "Create upload part URL (UploadPart).",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			partNumber, err := strconv.ParseInt(uploadPartOpts.partNumber, 10, 32)
 			if err != nil {
@@ -45,16 +45,16 @@ func NewUploadPartCmd(opts *CmdOptions) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&uploadPartOpts.bucketName, "bucketName", "b", "", "Bucket name")
+	cmd.Flags().StringVarP(&uploadPartOpts.bucketName, "bucketName", "b", "", "Bucket name (required)")
 	cmd.MarkFlagRequired("bucketName")
 
-	cmd.Flags().StringVarP(&uploadPartOpts.objectKey, "objectKey", "k", "", "Object key")
+	cmd.Flags().StringVarP(&uploadPartOpts.objectKey, "objectKey", "k", "", "Object key (required)")
 	cmd.MarkFlagRequired("objectKey")
 
-	cmd.Flags().StringVarP(&uploadPartOpts.uploadId, "uploadId", "u", "", "Upload ID")
+	cmd.Flags().StringVarP(&uploadPartOpts.uploadId, "uploadId", "u", "", "Upload ID (required)")
 	cmd.MarkFlagRequired("uploadId")
 
-	cmd.Flags().StringVarP(&uploadPartOpts.partNumber, "partNumber", "p", "", "Part number")
+	cmd.Flags().StringVarP(&uploadPartOpts.partNumber, "partNumber", "p", "", "Part number (required)")
 	cmd.MarkFlagRequired("partNumber")
 
 	return cmd


### PR DESCRIPTION
## Changes
This PR improves the documentation and help messages across all commands to provide better clarity and consistency.

### Documentation Updates
- Updated the main description in README.md to explicitly mention multipart upload functionality
- Added detailed parameter descriptions for the upload_part command:
  - `-u <upload_id>`: Required for upload_part. The ID of the multipart upload.
  - `-p <part_number>`: Required for upload_part. The part number of the multipart upload.

### Command Description Standardization
Standardized all command descriptions to clearly indicate that they generate presigned URLs:
- `put`: "Create upload URL (PutObject)"
- `get`: "Create download URL (GetObject)"
- `delete`: "Create delete URL (DeleteObject)"
- `upload_part`: "Create upload part URL (UploadPart)"

### Parameter Help Improvements
- Added "(required)" suffix to all mandatory parameters to make it clear which parameters are necessary
- Improved consistency in parameter descriptions across all commands
- Enhanced clarity of parameter requirements in help messages

## Why
These changes improve the user experience by:
1. Making it immediately clear that the tool generates presigned URLs
2. Providing more detailed information about multipart upload parameters
3. Clearly indicating which parameters are required
4. Maintaining consistency across all command descriptions

## Testing
- Verified all command help messages display correctly
- Confirmed README.md formatting is correct
- Tested all commands to ensure functionality remains unchanged